### PR TITLE
data_provider files added in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,8 @@ lib_opcodes_src = files(
 lib_core_src = files(
   'src/lib/hbc.c',
   'src/lib/r2.c',
+  'src/lib/data_provider_file.c',
+  'src/lib/data_provider_buffer.c',
 )
 
 lib_src = lib_core_src + lib_utils_src + lib_parsers_src + lib_disasm_src + lib_decompile_src + lib_opcodes_src


### PR DESCRIPTION
data_provider_file.c and data_provider_buffer.c files added in meson.build 
tried on windows 11 x64 system. both compile - install processes are working 

![meson2](https://github.com/user-attachments/assets/f819213a-a14d-437c-b71d-dadf4d8c04f1)
![meson1](https://github.com/user-attachments/assets/46248af7-06d3-4b8d-a2f1-fc0fdac48f50)
