### PR TITLE
r2r offline mode removed in Makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 all: new
 
 new:
-	r2r -u db/extras
+	r2r db/extras
 
 # old testsuite used in travis not used nowadays, needs care
 old:


### PR DESCRIPTION
in test/Makefile config, r2r using with -u - offline flag command. 
-u parameter removed and all tests passed.

<img width="1152" height="204" alt="Screenshot 2025-12-20 at 20 16 33" src="https://github.com/user-attachments/assets/b63af36c-df39-431e-888e-8fcae2bab9fa" />
