### PR TITLE
parser: bound v97 objShapeTableCount to prevent allocation DoS

### DIFF
--- a/src/lib/parsers/hbc_file_parser.c
+++ b/src/lib/parsers/hbc_file_parser.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define HBC_MAX_OBJECT_SHAPE_TABLE_COUNT 1000000U
+
 /* Initialize HBC reader */
 Result _hbc_reader_init(HBCReader *reader) {
 	R_RETURN_VAL_IF_FAIL (reader,
@@ -262,6 +264,10 @@ Result _hbc_reader_read_header(HBCReader *reader) {
 
 	if (version >= 97) {
 		RETURN_IF_ERROR (_hbc_buffer_reader_read_u32 (&reader->file_buffer, &reader->header.objShapeTableCount));
+		if (reader->header.objShapeTableCount > HBC_MAX_OBJECT_SHAPE_TABLE_COUNT) {
+			return ERROR_RESULT (RESULT_ERROR_INVALID_FORMAT,
+				"Object shape table count unreasonably large, likely not a valid Hermes bytecode file");
+		}
 		reader->header.arrayBufferSize = reader->header.literalValueBufferSize;
 		reader->header.objValueBufferSize = reader->header.literalValueBufferSize;
 	} else {


### PR DESCRIPTION
### Motivation
- Prevent an attacker-controlled `objShapeTableCount` (v97+) from driving unbounded allocations and long loops which can cause memory exhaustion or DoS when parsing crafted HBC files.

### Description
- Add a sanity cap `HBC_MAX_OBJECT_SHAPE_TABLE_COUNT` and return `RESULT_ERROR_INVALID_FORMAT` from `_hbc_reader_read_header` when a v97+ `objShapeTableCount` exceeds the limit, leaving downstream parsing logic unchanged.

### Testing
- Built the project with `make` and ran `make test`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2d9b424883318bee7f582189687f)