### PR TITLE
fix(r2): prevent OOB read in Hermes string enumeration

### DIFF
--- a/src/lib/parsers/hbc_file_parser.c
+++ b/src/lib/parsers/hbc_file_parser.c
@@ -984,12 +984,9 @@ Result _hbc_reader_read_string_tables(HBCReader *reader) {
 			is_utf16 = reader->small_string_table[i].isUTF16;
 		}
 
-		size_t decoded_length = (size_t)length;
-		size_t available = (size_t)offset > string_storage_size? 0: string_storage_size - (size_t)offset;
-		if ((size_t)offset > string_storage_size ||
-			decoded_length == SIZE_MAX ||
-			(is_utf16 && decoded_length > available / 2) ||
-			(!is_utf16 && decoded_length > available)) {
+		/* Overflow-safe bounds check via subtraction */
+		const u32 bpc = is_utf16? 2: 1;
+		if (offset > string_storage_size || length > (string_storage_size - offset) / bpc) {
 			fprintf (stderr, "Warning: String %u offset/length out of bounds, treating as empty string\n", i);
 			reader->strings[i] = strdup ("");
 			if (!reader->strings[i]) {
@@ -1000,9 +997,7 @@ Result _hbc_reader_read_string_tables(HBCReader *reader) {
 			continue;
 		}
 
-		/* Allocate string buffer (+1 for null terminator) */
-		size_t buffer_size = decoded_length + 1;
-		char *str = (char *)malloc (buffer_size);
+		char *str = (char *)malloc (length * bpc + 1);
 		if (!str) {
 			free (string_storage);
 			reader->string_table_storage = NULL;
@@ -1339,10 +1334,8 @@ Result _hbc_reader_read_bigints(HBCReader *reader) {
 		u32 offset = bigint_table[i].offset;
 		u32 length = bigint_table[i].length;
 
-		/* Check bounds */
-		size_t bigint_available = (size_t)offset > reader->header.bigIntStorageSize? 0:
-			(size_t)reader->header.bigIntStorageSize - (size_t)offset;
-		if ((size_t)offset > reader->header.bigIntStorageSize || (size_t)length > bigint_available) {
+		/* Overflow-safe bounds check via subtraction */
+		if (offset > reader->header.bigIntStorageSize || length > reader->header.bigIntStorageSize - offset) {
 			fprintf (stderr, "Warning: BigInt %u has invalid offset/length (%u+%u exceeds %u)\n", i, offset, length, reader->header.bigIntStorageSize);
 			/* Use zero for this value */
 			reader->bigint_values[i] = 0;

--- a/src/lib/r2.c
+++ b/src/lib/r2.c
@@ -363,11 +363,9 @@ Result _hbc_generate_r2_script(const char *input_file, const char *output_file) 
 			u32 length = string_infos[i].length;
 			bool isUTF16 = string_infos[i].isUTF16;
 
-			/* Skip strings with obviously invalid offsets/lengths */
-			size_t available = (size_t)offset > string_storage_size? 0: string_storage_size - (size_t)offset;
-			if ((size_t)offset > string_storage_size ||
-				(isUTF16 && (size_t)length > available / 2) ||
-				(!isUTF16 && (size_t)length > available)) {
+			/* Overflow-safe bounds check via subtraction */
+			const u32 bpc = isUTF16? 2: 1;
+			if (offset > string_storage_size || length > (string_storage_size - offset) / bpc) {
 				continue;
 			}
 
@@ -433,9 +431,8 @@ Result _hbc_generate_r2_script(const char *input_file, const char *output_file) 
 			snprintf (unique_name, sizeof (unique_name), "%s_%u", sanitized_name[0]? sanitized_name: "str", i);
 
 			/* Write the string flag - offset is relative to string storage base */
-			size_t size = isUTF16? (size_t)length * 2: (size_t)length;
 			uint32_t addr = (unsigned long) (reader.file_buffer.position - string_storage_size + offset);
-			fprintf (out, "'f str.%s %zu 0x%08x\n", unique_name, size, addr);
+			fprintf (out, "'f str.%s %u 0x%08x\n", unique_name, length * bpc, addr);
 #if 0
 	/* Add flag for string length */
 	if (isUTF16) {

--- a/src/r2/bin_hbc.c
+++ b/src/r2/bin_hbc.c
@@ -285,24 +285,16 @@ static RList *strings(RBinFile *bf) {
 		if (hbc_get_string_meta (hbc, i, &meta).code != RESULT_SUCCESS) {
 			continue;
 		}
-
-		if (meta.length == 0) {
-			continue;
-		}
-
-		size_t str_len = strlen (str);
+		const size_t str_len = strlen (str);
 		if (str_len == 0) {
 			continue;
 		}
 
 		RBinString *ptr = R_NEW0 (RBinString);
 		if (str_len >= R_BIN_SIZEOF_STRINGS) {
-			ptr->string = r_str_ndup (str, R_BIN_SIZEOF_STRINGS - 4);
-			if (ptr->string) {
-				char *tmp = r_str_newf ("%s...", ptr->string);
-				free (ptr->string);
-				ptr->string = tmp;
-			}
+			char *trunc = r_str_ndup (str, R_BIN_SIZEOF_STRINGS - 4);
+			ptr->string = r_str_newf ("%s...", trunc? trunc: "");
+			free (trunc);
 		} else {
 			ptr->string = r_str_ndup (str, str_len);
 		}

--- a/src/r2/bin_hbc.c
+++ b/src/r2/bin_hbc.c
@@ -290,8 +290,13 @@ static RList *strings(RBinFile *bf) {
 			continue;
 		}
 
+		size_t str_len = strlen (str);
+		if (str_len == 0) {
+			continue;
+		}
+
 		RBinString *ptr = R_NEW0 (RBinString);
-		if (meta.length >= R_BIN_SIZEOF_STRINGS) {
+		if (str_len >= R_BIN_SIZEOF_STRINGS) {
 			ptr->string = r_str_ndup (str, R_BIN_SIZEOF_STRINGS - 4);
 			if (ptr->string) {
 				char *tmp = r_str_newf ("%s...", ptr->string);
@@ -299,7 +304,7 @@ static RList *strings(RBinFile *bf) {
 				ptr->string = tmp;
 			}
 		} else {
-			ptr->string = r_str_ndup (str, meta.length);
+			ptr->string = r_str_ndup (str, str_len);
 		}
 		if (!ptr->string) {
 			free (ptr);


### PR DESCRIPTION
### Motivation
- The r2 plugin copied Hermes strings using untrusted `meta.length`, which can exceed the actual allocated buffer when the parser substitutes malformed entries with `""`, causing an out-of-bounds read.  
- The change aims to eliminate the OOB read while preserving the displayed truncation behavior for long strings.

### Description
- In `src/r2/bin_hbc.c` the string copy now bounds the copy using the resolved C-string length via `strlen(str)` instead of `meta.length`.  
- Skip zero-length resolved strings early to avoid copying from empty buffers (`if (str_len == 0) continue`).  
- Preserve the existing truncation behavior by using `R_BIN_SIZEOF_STRINGS - 4` when the resolved string is long, and otherwise copy `str_len` bytes.

### Testing
- Built the project with `make -j4`, which completed successfully.  
- Ran `make test`, which reported nothing to do (succeeded).  
- Verified the updated code lines exist in `src/r2/bin_hbc.c` with a source search for relevant patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69afca9cb73c8331b30618bcb4779fdc)