### PR TITLE
decompiler: reject overflowed anchor-map bytecode size

### DIFF
--- a/src/lib/decompilation/decompiler.c
+++ b/src/lib/decompilation/decompiler.c
@@ -1187,6 +1187,9 @@ Result _hbc_pass1_set_metadata(HermesDecompiler *state, DecompiledFunctionBody *
 	HBCReader *reader = state->hbc_reader;
 	FunctionHeader *fh = function_body->function_object;
 	u32 func_sz = fh->bytecodeSizeInBytes;
+	if (func_sz == UINT32_MAX) {
+		return ERROR_RESULT (RESULT_ERROR_PARSING_FAILED, "invalid bytecode size");
+	}
 
 	/* Function name - prefer flag name from r2 over embedded name */
 	const char *name = NULL;


### PR DESCRIPTION
### Motivation
- Prevent an integer overflow when computing `map_sz = func_sz + 1` in `_hbc_pass1_set_metadata` where `func_sz` is taken from untrusted `FunctionHeader.bytecodeSizeInBytes`, which could wrap to 0 and lead to zero-sized allocations and out-of-bounds writes.

### Description
- Add a guard in `_hbc_pass1_set_metadata` to reject `func_sz == UINT32_MAX` and return `RESULT_ERROR_PARSING_FAILED`, preventing `map_sz` from overflowing before anchor-map allocations in `src/lib/decompilation/decompiler.c`.

### Testing
- Built the project with `make -j4` which completed successfully. 
- Ran `make test` which reported nothing to do and returned successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69af3792c604833185f696560d22f169)