### PR TITLE
fix(assembler): reject unexpected extra operands in encoder parser

### DIFF
--- a/src/lib/opcodes/encoder.c
+++ b/src/lib/opcodes/encoder.c
@@ -131,7 +131,7 @@ Result hbc_encoder_parse_instruction(HBCEncoder *encoder, const char *asm_line, 
 	}
 
 	/* Parse operands separated by commas */
-	while (*line && operand_count < 6) {
+	while (*line) {
 		/* Skip whitespace */
 		while (*line && isspace (*line)) {
 			line++;
@@ -177,13 +177,16 @@ Result hbc_encoder_parse_instruction(HBCEncoder *encoder, const char *asm_line, 
 		}
 		*trim_end = '\0';
 
-		/* Parse operand based on expected type */
-		if (operand_count < 6 && inst->operands[operand_count].operand_type != OPERAND_TYPE_NONE) {
-			OperandType expected_type = inst->operands[operand_count].operand_type;
-			char *endptr;
-			bool parse_success = false;
+		if (operand_count >= 6 || inst->operands[operand_count].operand_type == OPERAND_TYPE_NONE) {
+			return ERROR_RESULT (RESULT_ERROR_PARSING_FAILED, "Incorrect number of operands");
+		}
 
-			switch (expected_type) {
+		/* Parse operand based on expected type */
+		OperandType expected_type = inst->operands[operand_count].operand_type;
+		char *endptr;
+		bool parse_success = false;
+
+		switch (expected_type) {
 			case OPERAND_TYPE_REG8:
 			case OPERAND_TYPE_REG32:
 				/* Register: rN or RN */
@@ -268,12 +271,11 @@ Result hbc_encoder_parse_instruction(HBCEncoder *encoder, const char *asm_line, 
 				break;
 			}
 
-			if (!parse_success) {
-				return ERROR_RESULT (RESULT_ERROR_PARSING_FAILED, "Invalid operand format");
-			}
-
-			operand_count++;
+		if (!parse_success) {
+			return ERROR_RESULT (RESULT_ERROR_PARSING_FAILED, "Invalid operand format");
 		}
+
+		operand_count++;
 
 		/* Move to next operand */
 		line = operand_end;

--- a/test/db/extras/hbc-disasm
+++ b/test/db/extras/hbc-disasm
@@ -284,7 +284,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=hbc assembler
+NAME=hbc pa ret
 FILE=--
 CMDS=<<EOF
 -a hbc
@@ -294,3 +294,290 @@ EXPECT=<<EOF
 5c00
 EOF
 RUN
+
+NAME=hbc pa get_global_object
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa get_global_object r0
+EOF
+EXPECT=<<EOF
+3000
+EOF
+RUN
+
+NAME=hbc pa mov two regs
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa mov r2, r1
+EOF
+EXPECT=<<EOF
+080201
+EOF
+RUN
+
+NAME=hbc pa construct three operands
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa construct r0, r0, 1
+EOF
+EXPECT=<<EOF
+50000001
+EOF
+RUN
+
+NAME=hbc pa select_object three regs
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa select_object r0, r1, r0
+EOF
+EXPECT=<<EOF
+6b000100
+EOF
+RUN
+
+NAME=hbc pa store_to_environment
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa store_to_environment r1, 1, r0
+EOF
+EXPECT=<<EOF
+2a010100
+EOF
+RUN
+
+NAME=hbc pa rejects extra operand
+FILE=--
+CMDS=<<EOF
+-a hbc
+"pa ret r0, r1"
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=hbc pa rejects multiple extra operands
+FILE=--
+CMDS=<<EOF
+-a hbc
+"pa ret r0, r1, r2"
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=hbc pa rejects extra operand on zero-arg instr
+FILE=--
+CMDS=<<EOF
+-a hbc
+"pa get_global_object r0, r1"
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=hbc pa rejects missing operand
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa ret
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=hbc pa rejects truncated mov
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa mov r2
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=hbc pa rejects unknown mnemonic
+FILE=--
+CMDS=<<EOF
+-a hbc
+pa bogus_op r0
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=hbc pad ret
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad 5c00
+EOF
+EXPECT=<<EOF
+ret r0
+EOF
+RUN
+
+NAME=hbc pad get_global_object
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad 3000
+EOF
+EXPECT=<<EOF
+get_global_object r0
+EOF
+RUN
+
+NAME=hbc pad mov
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad 080201
+EOF
+EXPECT=<<EOF
+mov r2, r1
+EOF
+RUN
+
+NAME=hbc pad construct
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad 50000001
+EOF
+EXPECT=<<EOF
+construct r0, r0, 1
+EOF
+RUN
+
+NAME=hbc pad select_object
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad 6b000100
+EOF
+EXPECT=<<EOF
+select_object r0, r1, r0
+EOF
+RUN
+
+NAME=hbc pad store_to_environment
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad 2a010100
+EOF
+EXPECT=<<EOF
+store_to_environment r1, 1, r0
+EOF
+RUN
+
+NAME=hbc pa+pad roundtrip ret
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad `pa ret r0`
+EOF
+EXPECT=<<EOF
+ret r0
+EOF
+RUN
+
+NAME=hbc pa+pad roundtrip mov
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad `pa mov r2, r1`
+EOF
+EXPECT=<<EOF
+mov r2, r1
+EOF
+RUN
+
+NAME=hbc pa+pad roundtrip construct
+FILE=--
+CMDS=<<EOF
+-a hbc
+pad `pa construct r0, r0, 1`
+EOF
+EXPECT=<<EOF
+construct r0, r0, 1
+EOF
+RUN
+
+NAME=hbc pi ret after wx
+FILE=malloc://16
+CMDS=<<EOF
+-a hbc
+wx 5c00
+pi 1
+EOF
+EXPECT=<<EOF
+ret r0
+EOF
+RUN
+
+NAME=hbc pi mov after wx
+FILE=malloc://16
+CMDS=<<EOF
+-a hbc
+wx 080201
+pi 1
+EOF
+EXPECT=<<EOF
+mov r2, r1
+EOF
+RUN
+
+NAME=hbc pi construct after wx
+FILE=malloc://16
+CMDS=<<EOF
+-a hbc
+wx 50000001
+pi 1
+EOF
+EXPECT=<<EOF
+construct r0, r0, 1
+EOF
+RUN
+
+NAME=hbc pa+wx+pi roundtrip ret
+FILE=malloc://16
+CMDS=<<EOF
+-a hbc
+wx `pa ret r0`
+pi 1
+EOF
+EXPECT=<<EOF
+ret r0
+EOF
+RUN
+
+NAME=hbc pa+wx+pi roundtrip mov
+FILE=malloc://16
+CMDS=<<EOF
+-a hbc
+wx `pa mov r2, r1`
+pi 1
+EOF
+EXPECT=<<EOF
+mov r2, r1
+EOF
+RUN
+
+NAME=hbc pa+wx+pi roundtrip store_to_environment
+FILE=malloc://16
+CMDS=<<EOF
+-a hbc
+wx `pa store_to_environment r1, 1, r0`
+pi 1
+EOF
+EXPECT=<<EOF
+store_to_environment r1, 1, r0
+EOF
+RUN
+


### PR DESCRIPTION
### Motivation

- Fix a parsing regression where extra operands were silently ignored because `operand_count` was only incremented when the current instruction definition expected an operand, allowing malformed assembly like `Mov r1, r2, r3` to be accepted.

### Description

- Change `hbc_encoder_parse_instruction` in `src/lib/opcodes/encoder.c` to explicitly check for unexpected operands before attempting to parse each token and return an error if the instruction has no remaining operand slots or more than 6 operands are provided.
- Replace the previous permissive loop condition with a strict early-return when `operand_count >= 6` or the next expected operand type is `OPERAND_TYPE_NONE`, and keep existing operand-type parsing and validation logic intact.
- Move and normalize the `operand_count++` and parsing checks so extra operands cannot be skipped and dropped silently.

### Testing

- Ran `make` and the project built successfully.
- Ran `make test` (no tests needed / nothing to do) and it completed without errors.
- Manual validation using the assembler: `./bin/libhbctool a 'Mov r1, r2'` succeeds and `./bin/libhbctool a 'Mov r1, r2, r3'` now fails with `Incorrect number of operands`, demonstrating the regression is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69af37b4fb3c83318c476ed903dea55e)