### PR TITLE
Fix decompilation abort on v98 deduped zero-size functions

### DIFF
--- a/include/hbc/parser.h
+++ b/include/hbc/parser.h
@@ -313,6 +313,22 @@ Result _hbc_reader_read_debug_info_header(HBCReader *reader);
 Result _hbc_reader_read_debug_info(HBCReader *reader);
 Result _hbc_reader_read_whole_file(HBCReader *reader, const char *filename);
 
+/*
+ * Recover the bytecode size for a deduplicated function.
+ *
+ * In bytecode versions that deduplicate identical function bodies (observed
+ * with v98 bundles), a deduped function stores bytecodeSizeInBytes == 0 in
+ * its (small or large) header while keeping a valid offset pointing at the
+ * shared canonical body owned by another function. This helper scans the
+ * function table for a function sharing \p fh->offset with a non-zero size
+ * and returns that size so the deduped function can be parsed/decompiled
+ * using the canonical body.
+ *
+ * \return the recovered size, or 0 if \p fh already has a non-zero size, or
+ *         if no canonical function is found (genuinely empty function).
+ */
+u32 _hbc_reader_resolve_deduped_size(const HBCReader *reader, const FunctionHeader *fh);
+
 /* Utility functions */
 const char *_hbc_string_kind_to_string(StringKind kind);
 BytecodeModule *_hbc_get_bytecode_module(u32 bytecode_version);

--- a/src/lib/decompilation/decompiler.c
+++ b/src/lib/decompilation/decompiler.c
@@ -26,6 +26,12 @@ static Result ensure_function_bytecode_loaded_from_state(HBC *hbc, FunctionHeade
 		return SUCCESS_RESULT ();
 	}
 
+	/* Recover the canonical size for deduplicated functions, which encode
+	 * bytecodeSizeInBytes == 0 while pointing at a shared body. */
+	if (function_header->bytecodeSizeInBytes == 0) {
+		function_header->bytecodeSizeInBytes = _hbc_reader_resolve_deduped_size (&hbc->reader, function_header);
+	}
+
 	/* Get bytecode from state */
 	const u8 *bytecode_ptr = NULL;
 	u32 bytecode_size = 0;
@@ -55,6 +61,12 @@ static Result ensure_function_bytecode_loaded(HBCReader *reader, u32 function_id
 	FunctionHeader *function_header = &reader->function_headers[function_id];
 	if (function_header->bytecode) {
 		return SUCCESS_RESULT ();
+	}
+
+	/* Recover the canonical size for deduplicated functions, which encode
+	 * bytecodeSizeInBytes == 0 while pointing at a shared body. */
+	if (function_header->bytecodeSizeInBytes == 0) {
+		function_header->bytecodeSizeInBytes = _hbc_reader_resolve_deduped_size (reader, function_header);
 	}
 
 	/* Skip invalid offsets */
@@ -967,9 +979,18 @@ static Result decompile_emit(HermesDecompiler *dec, u32 func_count, u32 version,
 			if (dec->decompiled_functions[i]) {
 				continue;
 			}
-			r = _hbc_decompile_function (dec, i, NULL, -1, false, false, false);
-			if (r.code == RESULT_SUCCESS) {
+			Result fr = _hbc_decompile_function (dec, i, NULL, -1, false, false, false);
+			if (fr.code == RESULT_SUCCESS) {
 				r = _hbc_string_buffer_append (&dec->output, "\n\n");
+			} else {
+				/* A single function failing must not abort the whole
+				 * bundle: emit a stub marker and keep decompiling the
+				 * remaining functions. A genuine memory/IO failure on the
+				 * append itself still terminates the run. */
+				char buf[160];
+				snprintf (buf, sizeof (buf), "// Function %u: skipped (%s)\n\n",
+					i, fr.error_message[0] != '\0'? fr.error_message: "unknown error");
+				r = _hbc_string_buffer_append (&dec->output, buf);
 			}
 		}
 	}

--- a/src/lib/hbc.c
+++ b/src/lib/hbc.c
@@ -498,11 +498,17 @@ Result hbc_get_function_bytecode(HBC *hbc, u32 function_id, const u8 **out_ptr, 
 		return ERROR_RESULT (RESULT_ERROR_INVALID_ARGUMENT, "Function ID out of range");
 	}
 	const FunctionHeader *fh = &hbc->reader.function_headers[function_id];
-	if (fh->offset > hbc->reader.file_buffer.size || fh->bytecodeSizeInBytes > hbc->reader.file_buffer.size - fh->offset) {
+	/* Recover the canonical size for deduplicated functions, which encode
+	 * bytecodeSizeInBytes == 0 while pointing at a shared body. */
+	u32 size = fh->bytecodeSizeInBytes;
+	if (size == 0) {
+		size = _hbc_reader_resolve_deduped_size (&hbc->reader, fh);
+	}
+	if (fh->offset > hbc->reader.file_buffer.size || size > hbc->reader.file_buffer.size - fh->offset) {
 		return ERROR_RESULT (RESULT_ERROR_INVALID_DATA, "Function bytecode range is out of bounds");
 	}
 	*out_ptr = hbc->reader.file_buffer.data + fh->offset;
-	*out_size = fh->bytecodeSizeInBytes;
+	*out_size = size;
 	return SUCCESS_RESULT ();
 }
 

--- a/src/lib/parsers/hbc_file_parser.c
+++ b/src/lib/parsers/hbc_file_parser.c
@@ -526,6 +526,29 @@ static Result validate_function_bytecode_range(const HBCReader *reader, const Fu
 	return SUCCESS_RESULT ();
 }
 
+u32 _hbc_reader_resolve_deduped_size(const HBCReader *reader, const FunctionHeader *fh) {
+	if (!reader || !fh || !reader->function_headers) {
+		return 0;
+	}
+	/* Nothing to do if the function already has a non-zero size, or if it
+	 * has no offset to dedup against. */
+	if (fh->bytecodeSizeInBytes != 0 || fh->offset == 0) {
+		return fh->bytecodeSizeInBytes;
+	}
+	/* Search for a canonical function sharing this offset with a real body.
+	 * Deduped functions encode size==0 while pointing at the shared body. */
+	for (u32 i = 0; i < reader->header.functionCount; i++) {
+		const FunctionHeader *other = &reader->function_headers[i];
+		if (other == fh) {
+			continue;
+		}
+		if (other->offset == fh->offset && other->bytecodeSizeInBytes > 0) {
+			return other->bytecodeSizeInBytes;
+		}
+	}
+	return 0;
+}
+
 static Result load_function_bytecode(HBCReader *reader, FunctionHeader *header) {
 	if (!header->bytecodeSizeInBytes) {
 		return SUCCESS_RESULT ();


### PR DESCRIPTION
v98 bundles deduplicate identical function bodies by storing bytecodeSizeInBytes == 0 in the deduped function's header while keeping its offset pointing at the shared canonical body owned by another function. The parser treated size==0 as a hard error and decompile_emit aborted the whole run on the first such function, so v98 React Native bundles failed with "Function has zero bytecode size".

Add _hbc_reader_resolve_deduped_size() which recovers the canonical size by finding a non-zero-size function sharing the same offset, and call it from the bytecode-loading paths (hbc_get_function_bytecode and both ensure_function_bytecode_loaded variants) before parsing. Also make decompile_emit's decomp_all loop resilient so any future single-function error emits a stub marker and continues instead of killing the entire bundle output.

Verified on new.index.android.bundle (v98, 33146 functions): all functions now decompile with zero skipped; ASAN-clean.
